### PR TITLE
Fix tests on Elixir 1.7.3

### DIFF
--- a/test/expression_test.exs
+++ b/test/expression_test.exs
@@ -175,7 +175,7 @@ defmodule ExpressionTest do
 
     expected = """
       defp foo() do
-        not a
+        not(a)
         a or b
         a and b
         :erlang.and(a, b)
@@ -792,12 +792,12 @@ defmodule ExpressionTest do
             e
           kind, h ->
             {kind, h}
-        after
-          f
-          g
         else
           a ->
             a + 2
+        after
+          f
+          g
         end
       end
       """

--- a/test/preprocessor_test.exs
+++ b/test/preprocessor_test.exs
@@ -805,7 +805,7 @@ defmodule PreprocessorTest do
     expected = """
       defmacrop erlmacro_HELLO(a, b) do
         quote do
-          {unquote(a), fn -> unquote(b) end.()}
+          {unquote(a), (fn -> unquote(b) end).()}
         end
       end
 

--- a/test/type_test.exs
+++ b/test/type_test.exs
@@ -178,9 +178,9 @@ defmodule TypeTest do
 
       @typep type4() :: <<_::10>>
 
-      @typep type5() :: <<_::_ * 8>>
+      @typep type5() :: <<_::_*8>>
 
-      @typep type6() :: <<_::10, _::_ * 8>>
+      @typep type6() :: <<_::10, _::_*8>>
       """
 
     assert Erl2ex.convert_str!(input, @opts) == expected


### PR DESCRIPTION
This PR fixes all the tests to run on Elixir 1.7.3. I guess ideally we'd pin the tests to a specific Elixir version since the output of the Elixir compiler will always change on newer versions.