### PR TITLE
Fix compilation warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: elixir
 
 elixir:
-  - 1.3.2
+  - 1.4.5
 otp_release:
   - 18.3
   - 19.0

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Erl2ex may be run as a mix task or as a standalone escript.
 
 ### Requirements
 
-Erl2ex recognizes Erlang source that is compatible with Erlang 18.x. The generated Elixir source requires Elixir 1.2 or later. The Erl2ex tool itself also requires Elixir 1.2 or later.
+Erl2ex recognizes Erlang source that is compatible with Erlang 18.x. The generated Elixir source requires Elixir 1.4 or later. The Erl2ex tool itself also requires Elixir 1.4 or later.
 
 ### Installing the mix task
 

--- a/lib/erl2ex/cli.ex
+++ b/lib/erl2ex/cli.ex
@@ -46,7 +46,7 @@ defmodule Erl2ex.Cli do
       not Enum.empty?(errors) ->
         display_errors(errors)
       Keyword.get(options, :help) ->
-        display_help
+        display_help()
       true ->
         run_conversion(args, options)
     end
@@ -156,7 +156,7 @@ defmodule Erl2ex.Cli do
 
   defp run_conversion(paths, _) do
     IO.puts(:stderr, "Got too many input paths: #{inspect(paths)}\n")
-    display_help
+    display_help()
     1
   end
 
@@ -178,7 +178,7 @@ defmodule Erl2ex.Cli do
         IO.puts(:stderr, "Unrecognized or malformed switch: #{switch}=#{val}")
       end)
     IO.puts(:stderr, "")
-    display_help
+    display_help()
     1
   end
 

--- a/lib/erl2ex/convert/context.ex
+++ b/lib/erl2ex/convert/context.ex
@@ -505,7 +505,7 @@ defmodule Erl2ex.Convert.Context do
     else
       arg_name = stringified_arg
         |> Atom.to_string
-        |> String.lstrip(??)
+        |> String.trim_leading("?")
         |> String.to_atom
       mapped_arg = Map.fetch!(variables_map, arg_name)
       mangled_name = mapped_arg

--- a/lib/erl2ex/convert/erl_expressions.ex
+++ b/lib/erl2ex/convert/erl_expressions.ex
@@ -701,7 +701,7 @@ defmodule Erl2ex.Convert.ErlExpressions do
 
   defp record_field_list(record_name, fields, context) do
     {ex_all_fields, context} = conv_list(fields, context)
-    {underscores, ex_fields} = Enum.partition(ex_all_fields, fn
+    {underscores, ex_fields} = Enum.split_with(ex_all_fields, fn
       {{:_, _, Elixir}, _} -> true
       {_, _} -> false
     end)

--- a/lib/erl2ex/convert/erl_forms.ex
+++ b/lib/erl2ex/convert/erl_forms.ex
@@ -406,7 +406,7 @@ defmodule Erl2ex.Convert.ErlForms do
 
   defp conv_attr_form(name, arg, context) do
     {name, arg} = conv_attr(name, arg)
-    register = not name in @auto_registered_attrs
+    register = not(name in @auto_registered_attrs)
 
     ex_attr = %ExAttr{
       name: name,

--- a/lib/erl2ex/pipeline/codegen.ex
+++ b/lib/erl2ex/pipeline/codegen.ex
@@ -283,7 +283,7 @@ defmodule Erl2ex.Pipeline.Codegen do
       |> write_string("defmacrop #{signature_to_string(signature)} do", io)
       |> increment_indent
       |> foreach(stringifications, fn(ctx, {var, str}) ->
-        write_string(ctx, "#{str} = Macro.to_string(quote do: unquote(#{var})) |> String.to_char_list", io)
+        write_string(ctx, "#{str} = Macro.to_string(quote do: unquote(#{var})) |> String.to_charlist", io)
       end)
     context =
       if guard_expr != nil do

--- a/lib/erl2ex/pipeline/module_data.ex
+++ b/lib/erl2ex/pipeline/module_data.ex
@@ -322,14 +322,14 @@ defmodule Erl2ex.Pipeline.ModuleData do
   # require init.
 
   def macros_that_need_init(%ModuleData{macros: macros}) do
-    macros |> Enum.filter_map(
-      fn
+    macros
+    |> Enum.filter(fn
         {_, %MacroData{requires_init: true}} -> true
         _ -> false
-      end,
-      fn {name, %MacroData{define_tracker: define_tracker}} ->
-        {name, define_tracker}
       end)
+    |> Enum.map(fn {name, %MacroData{define_tracker: define_tracker}} ->
+        {name, define_tracker}
+    end)
   end
 
 

--- a/lib/erl2ex/pipeline/names.ex
+++ b/lib/erl2ex/pipeline/names.ex
@@ -183,7 +183,7 @@ defmodule Erl2ex.Pipeline.Names do
     defimpl: 3,
     defmacro: 2,
     defmacrop: 2,
-    "defmodule": 2,
+    defmodule: 2,
     defoverridable: 1,
     defp: 2,
     defprotocol: 2,

--- a/lib/erl2ex/pipeline/parse.ex
+++ b/lib/erl2ex/pipeline/parse.ex
@@ -29,7 +29,7 @@ defmodule Erl2ex.Pipeline.Parse do
 
   defp generate_charlist(str) do
     str = if String.ends_with?(str, "\n"), do: str, else: str <> "\n"
-    String.to_char_list(str)
+    String.to_charlist(str)
   end
 
 

--- a/lib/erl2ex/pipeline/utils.ex
+++ b/lib/erl2ex/pipeline/utils.ex
@@ -27,7 +27,8 @@ defmodule Erl2ex.Pipeline.Utils do
 
   def find_available_name(basename, used_names, prefix, val) do
     suggestion = suggest_name(basename, prefix, val)
-    if Set.member?(used_names, suggestion) do
+    set = MapSet.new(used_names)
+    if MapSet.member?(set, suggestion) do
       find_available_name(basename, used_names, prefix, val + 1)
     else
       suggestion

--- a/mix.exs
+++ b/mix.exs
@@ -5,16 +5,16 @@ defmodule Erl2ex.Mixfile do
     [
       app: :erl2ex,
       version: "0.0.10",
-      elixir: "~> 1.3",
+      elixir: "~> 1.4",
       name: "Erl2ex",
       source_url: "https://github.com/dazuma/erl2ex",
-      build_embedded: Mix.env == :prod,
-      start_permanent: Mix.env == :prod,
+      build_embedded: Mix.env() == :prod,
+      start_permanent: Mix.env() == :prod,
       escript: [main_module: Erl2ex.Cli],
-      deps: deps,
-      docs: docs,
-      description: description,
-      package: package
+      deps: deps(),
+      docs: docs(),
+      description: description(),
+      package: package()
     ]
   end
 
@@ -51,5 +51,4 @@ defmodule Erl2ex.Mixfile do
       links: %{"GitHub" => "https://github.com/dazuma/erl2ex"}
     ]
   end
-
 end

--- a/test/preprocessor_test.exs
+++ b/test/preprocessor_test.exs
@@ -226,7 +226,7 @@ defmodule PreprocessorTest do
 
     expected = """
       defmacrop erlmacro_hello(x) do
-        str_x = Macro.to_string(quote do: unquote(x)) |> String.to_char_list
+        str_x = Macro.to_string(quote do: unquote(x)) |> String.to_charlist
         quote do
           unquote(str_x)
         end
@@ -254,7 +254,7 @@ defmodule PreprocessorTest do
 
     expected = """
       defmacrop erlmacro_hello(x) do
-        str2_x = Macro.to_string(quote do: unquote(x)) |> String.to_char_list
+        str2_x = Macro.to_string(quote do: unquote(x)) |> String.to_charlist
         quote do
           unquote(str2_x) ++ str_x()
         end
@@ -543,8 +543,8 @@ defmodule PreprocessorTest do
     expected = """
       defp foo() do
         __MODULE__
-        Atom.to_char_list(__MODULE__)
-        String.to_char_list(__ENV__.file())
+        Atom.to_charlist(__MODULE__)
+        String.to_charlist(__ENV__.file())
         __ENV__.line()
         'BEAM'
       end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -101,10 +101,12 @@ defmodule Erl2ex.TestHelper do
     cd = Keyword.get(opts, :cd, project_path(name, path))
     display_output = Keyword.get(opts, :display_output)
     display_cmd = Keyword.get(opts, :display_cmd)
-    env = opts |> Enum.filter_map(
-      fn {k, _} -> Regex.match?(~r/^[A-Z]/, Atom.to_string(k)) end,
-      fn {k, v} -> {Atom.to_string(k), v} end
-    )
+
+    env =
+      opts
+      |> Enum.filter(fn {k, _} -> Regex.match?(~r/^[A-Z]/, Atom.to_string(k)) end)
+      |> Enum.map(fn {k, v} -> {Atom.to_string(k), v} end)
+
     args = args |> Enum.flat_map(fn
       {wildcard} ->
         "#{cd}/#{wildcard}"


### PR DESCRIPTION
Fix all compilation warnings on Elixir 1.7.x. Everything should be backwards compatible up to 1.4 (released January 2017).

Based on #5 so that the tests pass but it could be rebased and then merged separately.