### PR TITLE
Make compatible with Elixir 1.11 boundary checking

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -19,7 +19,7 @@ defmodule Erl2ex.Mixfile do
   end
 
   def application do
-    [applications: [:logger]]
+    [extra_applications: [:logger, :syntax_tools]]
   end
 
   defp deps do


### PR DESCRIPTION
This changes remove warnings about the elixir boundary checking.
